### PR TITLE
Fix issue #39 (cannot access images when using custom-build catalogue image)

### DIFF
--- a/docker/catalogue/Dockerfile
+++ b/docker/catalogue/Dockerfile
@@ -9,6 +9,8 @@ RUN cd /go/src/github.com/microservices-demo/catalogue && gvt restore
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /app/main github.com/microservices-demo/catalogue/cmd/cataloguesvc
 
+WORKDIR /
+
 CMD ["/app/main", "-port=80"]
 
 EXPOSE 80


### PR DESCRIPTION
[https://github.com/microservices-demo/catalogue/issues/39](url)
The problem is the wrong workdir. Originally it was "/go". Now it is "/", like the hub image. Confirmed it works on local machine.
