### PR TITLE
Rename HTTP metrics

### DIFF
--- a/cmd/cataloguesvc/main.go
+++ b/cmd/cataloguesvc/main.go
@@ -31,10 +31,10 @@ const (
 
 var (
 	HTTPLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "request_duration_seconds",
+		Name:    "http_request_duration_seconds",
 		Help:    "Time (in seconds) spent serving HTTP requests.",
 		Buckets: prometheus.DefBuckets,
-	}, []string{"method", "route", "status_code", "isWS"})
+	}, []string{"method", "path", "status_code", "isWS"})
 )
 
 func init() {


### PR DESCRIPTION
Renames metrics from `request_duration_seconds` => `http_request_duration_seconds` and replaces the `route` label with `path`.