### PR TITLE
Change port to be 80 by default

### DIFF
--- a/cmd/cataloguesvc/main.go
+++ b/cmd/cataloguesvc/main.go
@@ -43,7 +43,7 @@ func init() {
 
 func main() {
 	var (
-		port   = flag.String("port", "8081", "Port to bind HTTP listener") // TODO(pb): should be -addr, default ":8081"
+		port   = flag.String("port", "80", "Port to bind HTTP listener") // TODO(pb): should be -addr, default ":80"
 		images = flag.String("images", "./images/", "Image path")
 		dsn    = flag.String("DSN", "catalogue_user:default_password@tcp(catalogue-db:3306)/socksdb", "Data Source Name: [username[:password]@][protocol[(address)]]/dbname")
 		zip    = flag.String("zipkin", os.Getenv("ZIPKIN"), "Zipkin address")


### PR DESCRIPTION
- `Dockerfile` explicitly overrides `8081` with `80`, so might as well have it as the default: github.com/microservices-demo/catalogue/blob/master/docker/catalogue/Dockerfile#L45-L46
- Should one not realise this override is currently required (but no longer, after this change), issues like microservices-demo/microservices-demo/pull/767 could be experienced.