### PR TITLE
fix deprecated github actions add-path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Setup PATH
-        run: echo "::add-path::${GOPATH}/bin"
+        run: echo "${GOPATH}/bin" >> $GITHUB_PATH
 
       - name: Install dependencies
         run: go get -u github.com/FiloSottile/gvt && gvt restore && go get -v github.com/mattn/goveralls


### PR DESCRIPTION
The current build is [failing](https://github.com/microservices-demo/catalogue/runs/1681461858?check_suite_focus=true) in master as the ::add-path:: workflow command has been deprecated in github actions: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/.

This PR is to update the failing action following the [guidance](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#adding-a-system-path) from github.